### PR TITLE
fix: prevent jsonnet injections

### DIFF
--- a/lib/app_component.dart
+++ b/lib/app_component.dart
@@ -105,6 +105,6 @@ class SLOService {
       return response.body;
     }
 
-    return '';
+    return 'Error: ' + response.body;
   }
 }


### PR DESCRIPTION
Current code is vulnerable to Jsonnet code injections. While I did not
succeed doing anything incredibly harmful with it, it can be used to
stack-overflow the VM or do compute heavy things, such as repeatedly
computing base64.

Using the Prometheus recommended regular expressions for metric name and
labels mostly prevents this.

Label values are harder, as any unicode value is allowed. To avoid
breaking out of the string, I added a replacement to escape double
quotes. Not perfect, but seems to work.